### PR TITLE
Added "image" mode for capture image for SAVE node, Added preview resolution and FPS configuration for Model node

### DIFF
--- a/node-red-contrib-sscma/nodes/model.html
+++ b/node-red-contrib-sscma/nodes/model.html
@@ -250,6 +250,23 @@
         <input type="checkbox" id="node-input-debug" style="width:auto;">
     </div>
     <div class="form-row">
+        <label for="node-input-previewResolution"><i class="fa fa-expand"></i> Preview Resolution</label>
+        <select id="node-input-previewResolution" style="width: 60%;">
+            <option value="640x640">640x640 (Square)</option>
+            <option value="1280x720">1280x720 (HD)</option>
+            <option value="1920x1080">1920x1080 (Full HD)</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-previewFps"><i class="fa fa-clock-o"></i> Preview FPS</label>
+        <select id="node-input-previewFps" style="width: 60%;">
+            <option value="5">5 FPS</option>
+            <option value="10">10 FPS</option>
+            <option value="15">15 FPS</option>
+            <option value="30" selected>30 FPS</option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-trace"><i class="fa fa-toggle-on"></i> Trace</label>
         <input type="checkbox" id="node-input-trace" style="width:auto;">
     </div>
@@ -300,6 +317,8 @@
             counting: { value: false },
             classes: { value: "" },
             splitter: { value: "0,0,0,0" }, // Array for x1, y1, x2, y2
+            previewResolution: { value: "640x640" },
+            previewFps: { value: 30 },
             client: { type: "sscma", required: true, label: RED._("sscma") },
         },
         inputs: 1,

--- a/node-red-contrib-sscma/nodes/model.js
+++ b/node-red-contrib-sscma/nodes/model.js
@@ -18,6 +18,8 @@ module.exports = function (RED) {
                 .split(",")
                 .filter(Boolean)
                 .map((c) => c.trim()),
+            previewResolution: config.previewResolution,
+            previewFps: parseInt(config.previewFps),
         };
 
         node.on("input", function (msg) {

--- a/node-red-contrib-sscma/nodes/save.html
+++ b/node-red-contrib-sscma/nodes/save.html
@@ -15,6 +15,16 @@
         <input type="text" id="node-input-client" />
     </div>
     <div class="form-row">
+        <label for="node-input-saveMode">
+            <i class="fa fa-file"></i>
+            Save Mode
+        </label>
+        <select id="node-input-saveMode">
+            <option value="video" selected>Video (.mov)</option>
+            <option value="image">Image (.jpg) - 1920x1080</option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-storage">
             <i class="fa fa-folder"></i>
             Storage
@@ -34,7 +44,7 @@
     <div class="form-row">
         <label for="node-input-slice">
             <i class="fa fa-clock-o"></i>
-            Slice
+            <span id="slice-label">Slice</span>
         </label>
         <select id="node-input-slice" style="width: auto;">
             <option value="2">2</option>
@@ -53,13 +63,20 @@
             <i class="fa fa-hourglass-half"></i>
             Duration
         </label>
-        <input type="number" id="node-input-duration" min="0" placeholder="Enter 0 for continues or a value" style="width: 50%;" />
+        <input type="number" id="node-input-duration" min="0" placeholder="Enter 0 for manual mode or a value" style="width: 50%;" />
         <select id="node-input-durationUnit" style="width: auto; margin-left: 5px;">
             <option value="0">Seconds</option>
             <option value="1" selected>Minutes</option>
             <option value="2">Hours</option>
         </select>
     </div>
+    <div class="form-row" id="manual-mode-info" style="display: none;">
+        <label style="color: #666; font-style: italic;">
+            <i class="fa fa-info-circle"></i>
+            Manual Mode: Send message with payload="capture" to capture an image
+        </label>
+    </div>
+
 </script>
 <script type="text/javascript">
     RED.nodes.registerType("save", {
@@ -67,12 +84,14 @@
         color: "#D9A066",
         defaults: {
             name: { value: this.name || "save" },
+            saveMode: { value: "video" },
             slice: { value: "5" },
             timeUnit: { value: "1" },
             storage: { value: "local" },
             duration: { value: 0 }, // Default duration (0 means indefinite)
             durationUnit: { value: "1" }, // Default duration unit (1 means minutes)
             start: { value: true },
+
             client: { type: "sscma", required: true, label: RED._("sscma") },
         },
         inputs: 1,
@@ -81,7 +100,37 @@
         label: function () {
             return this.name || "save";
         },
-        oneditprepare: function () {},
+        oneditprepare: function () {
+            // Handle save mode change
+            $("#node-input-saveMode").on("change", function() {
+                var saveMode = $(this).val();
+                if (saveMode === "image") {
+                    $("#slice-label").text("Interval");
+                } else {
+                    $("#slice-label").text("Slice");
+                }
+                updateManualModeInfo();
+            });
+            
+            // Handle duration change for manual mode info
+            $("#node-input-duration").on("input", function() {
+                updateManualModeInfo();
+            });
+            
+            function updateManualModeInfo() {
+                var saveMode = $("#node-input-saveMode").val();
+                var duration = $("#node-input-duration").val();
+                if (saveMode === "image" && duration === "0") {
+                    $("#manual-mode-info").show();
+                } else {
+                    $("#manual-mode-info").hide();
+                }
+            }
+            
+            // Trigger initial state
+            $("#node-input-saveMode").trigger("change");
+            updateManualModeInfo();
+        },
         oneditsave: function () {},
         oneditcancel: function () {
             // Logic to handle cancellation if necessary
@@ -98,7 +147,6 @@
 <script type="text/markdown" data-help-name="save">
 This is the `Save node` for Seeed SenseCraft Model Assistant such as reCamera or Pi camera.
 
-
 ### Input
 Wire the camera node to the save node to enable the saving.
 
@@ -107,18 +155,33 @@ Wire the camera node to the save node to enable the saving.
 #### Configuration
 Please select sscma for the client. 
 
+#### Save Mode
+- **Video (.mov)**: Save video files in MOV format (default)
+- **Image (.jpg)**: Save high-quality JPEG images at 1920x1080 resolution using hardware JPEG encoding at 5 FPS
+
 #### Storage
 - **Local**: path: `recamera/userdata/VIDEO`
 - **External**: Stored in SD card.
 
 #### Start tickbox
-Once ticked, the saving will start immediately. Saving parameters will be based on the slice and duration below.
+Once ticked, the saving will start immediately. Saving parameters will be based on the slice/interval and duration below.
 
-#### Slice
+#### Slice (Video Mode)
 Video time length of each file you want to save. (You can change units in the dropdown menu with version 0.1.6 or above)
 
-#### Duration
-Total time length of the video you want to save. (You can change units in the dropdown menu with version 0.1.6 or above)
+#### Interval (Image Mode)
+Time interval between saved images. (You can change units in the dropdown menu)
 
-**Example**: if slice is set to 5 minutes and duration is set to 1 hour, the video will be saved in 12 files with 5 minutes each.
+#### Duration
+Total time length of the video/images you want to save. (You can change units in the dropdown menu with version 0.1.6 or above)
+
+**Manual Mode (Image only)**: Set duration to 0 for manual capture mode. In this mode, images are captured only when a message with `msg.payload = "capture"` is sent to the node.
+
+**Example Video**: if slice is set to 5 minutes and duration is set to 1 hour, the video will be saved in 12 files with 5 minutes each.
+
+**Example Image**: if interval is set to 30 seconds and duration is set to 1 hour, 120 images will be saved at 30-second intervals.
+
+**Example Manual Image**: set duration to 0, then send a message with payload = "capture" to capture and save an image.
+
+**Image Resolution**: If you want to save images in a different resolution, you must set the desired preview resolution in the Model node configuration. The Save node will use the preview resolution provided by the Model node.
 </script>

--- a/node-red-contrib-sscma/nodes/save.js
+++ b/node-red-contrib-sscma/nodes/save.js
@@ -4,6 +4,7 @@ module.exports = function (RED) {
         const node = this;
         node.client = RED.nodes.getNode(config.client);
         node.config = {
+            saveMode: config.saveMode || "video",
             storage: config.storage,
             slice: +config.slice * Math.pow(60, Number(config.timeUnit)),
             duration: +config.duration * Math.pow(60, Number(config.durationUnit)),
@@ -12,6 +13,15 @@ module.exports = function (RED) {
         node.on("input", function (msg) {
             if (msg.hasOwnProperty("enabled")) {
                 node.client.request(node.id, "enabled", msg.enabled);
+            }
+            
+            // Handle manual capture for image mode
+            if (node.config.saveMode === "image" && node.config.duration === 0) {
+                // Check if message contains capture command
+                if (msg.payload === "capture") {
+                    // Send capture command to backend
+                    node.client.request(node.id, "capture", true);
+                }
             }
         });
 


### PR DESCRIPTION
I would like to use your ReCamera as a control camera mounted on the head of a 6-axis robot operating a CNC machine. I want to use the camera to verify the correct workpiece setup before starting the program. Unfortunately, I encountered several issues that were missing in the current implementation. I am gradually trying to solve these problems and would like to give back the results of my work to the community.

The most critical issue was how to train my own model. For model training, I need sufficient images. Currently, the Node-RED save block unfortunately does not allow saving images, but only videos. I tried to save the base64 image from the Model block output to a file, but the image had very low resolution. Therefore, I decided to modify the Save block and add the option to save images. Here I encountered the issue that the JPEG channel is already being used for Model Preview with a fixed resolution of 640x640. I decided to share the JPEG channel with the MODEL block. Therefore, I added resolution and FPS selection options to the MODEL block (to reduce load at higher resolutions). The SAVE block then saves images according to the specified interval, or manually on payload "capture".

With this modification comes another PR:
https://github.com/Seeed-Studio/sscma-example-sg200x/pull/26
https://github.com/Seeed-Studio/OSHW-reCamera-Series/pulls

<img width="622" height="747" alt="image" src="https://github.com/user-attachments/assets/5369a980-038f-4df9-a117-81b3b1c77855" />

<img width="637" height="765" alt="image" src="https://github.com/user-attachments/assets/4c936e1c-7492-4482-a542-3ff4db0e6baa" />